### PR TITLE
fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: 3.7
 cache: pip
 install:
   - ./install_packer.sh || travis_terminate 1
-  - sudo snap install aws-cli
+  - sudo snap install aws-cli --classic
   - pip install pre-commit travis-wait-improved ansible
 before_script:
   - path=$(pwd)


### PR DESCRIPTION
fix the following issue
```
$ sudo snap install aws-cli
error: This revision of snap "aws-cli" was published using classic confinement
       and thus may perform arbitrary system changes outside of the security
       sandbox that snaps are usually confined to, which may put your system at
       risk.
       If you understand and want to proceed repeat the command including
       --classic.
```