### PR TITLE
[SC-409] Update base image to Amazon Linux 2023

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -3,22 +3,35 @@
 
 - hosts: all
   become: yes
-
   tasks:
     - name: Upgrade all packages
-      yum: name=* state=latest
+      yum:
+        name: "*"
+        state: latest
+        update_cache: true
 
     - name: Install system packages
       ansible.builtin.yum:
         name: "{{ item }}"
         state: present
       with_items:
-        - "curl"
         - "wget"
-        - "jq"
         - "git"
-        - "amazon-linux-extras"
-        - "docker"
+        - "python3-pip"
+        - "python3.11-pip"
+        - "ecs-init"
+
+    - name: Install python packages
+      ansible.builtin.pip:
+        name: "{{ item }}"
+      with_items:
+        - wheel
+        - synapseclient[pandas,pysftp]
+
+    - name: Install docker
+      ansible.builtin.yum:
+        name: "docker"
+        state: present
 
     - name: Start docker service
       ansible.builtin.service:
@@ -40,10 +53,14 @@
       with_items:
         - docker
 
-    - name: install python packages
-      ansible.builtin.pip:
-        name: "{{ item }}"
-        executable: pip3
-      with_items:
-        - docker-compose
-        - synapseclient[pandas,pysftp]
+    - name: Create docker plugin dir
+      ansible.builtin.file:
+        path: /usr/local/lib/docker/cli-plugins
+        state: directory
+        mode: '0755'
+
+    - name: Download docker-compose
+      ansible.builtin.get_url:
+        url: https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64
+        dest: /usr/local/lib/docker/cli-plugins/docker-compose
+        mode: +x

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -18,7 +18,6 @@
         - "wget"
         - "git"
         - "python3-pip"
-        - "python3.11-pip"
         - "ecs-init"
 
     - name: Install python packages

--- a/src/template.json
+++ b/src/template.json
@@ -26,7 +26,7 @@
       "source_ami_filter": {
         "filters": {
           "architecture": "x86_64",
-          "name": "*amzn2-ami-*",
+          "name": "*al2023-ami-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },


### PR DESCRIPTION
Amazon Linux 2 does not provide any RPM packages for recent versions of Python. Update the base image to Amazon Linux 2023 in order to upgrade the system Python version to 3.9. Also install Python3.11 alongside Python3.9.

Installing docker-compose with pip fails to upgrade requests because it was installed from RPM, and removing the requests RPM will also uninstall cloud-init, so instead manually install docker-compose into the plugin directory according to https://docs.docker.com/compose/install/linux/#install-the-plugin-manually
