### PR TITLE
Bugfix: install cfn-init and cfn-signal

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -19,6 +19,7 @@
         - "git"
         - "python3-pip"
         - "ecs-init"
+        - "aws-cfn-bootstrap"
 
     - name: Install python packages
       ansible.builtin.pip:


### PR DESCRIPTION
Install cfn-init and cfn-signal so that we can successfully create instances from cloudformation.