### PR TITLE
bugfix: add missing dependency for cloudformation

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -20,6 +20,7 @@
         - "python3-pip"
         - "ecs-init"
         - "aws-cfn-bootstrap"
+        - "chkconfig"
 
     - name: Install python packages
       ansible.builtin.pip:


### PR DESCRIPTION
The cfn-hup systemd service created by AWS::CloudFormation::Init on the instance depends on chkconfig being installed. Install chkconfig so that the cfn-hup service can signal resource completion.