### PR TITLE
Install synapseclient into /usr/lib

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,8 @@ jobs:
       - name: packer validate
         run: |
           pushd src
+          packer plugins install github.com/hashicorp/amazon
+          packer plugins install github.com/hashicorp/ansible
           packer validate -var AmiImageName=validate template.json
   deploy:
     name: Deploy to AWS org-sagebase-imagecentral

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -18,6 +18,7 @@
         - "wget"
         - "git"
         - "python3-pip"
+        - "python3-wheel"
         - "ecs-init"
         - "aws-cfn-bootstrap"
         - "chkconfig"
@@ -25,9 +26,13 @@
     - name: Install python packages
       ansible.builtin.pip:
         name: "{{ item }}"
+        extra_args: "--target /usr/lib"
       with_items:
-        - wheel
         - synapseclient[pandas,pysftp]
+
+    - name: List all python packages
+      ansible.builtin.command:
+        cmd: pip3 freeze
 
     - name: Install docker
       ansible.builtin.yum:


### PR DESCRIPTION
By default, pip will install packages into /usr/local/lib, and synapseclient attempts to upgrade python-dateutil, causing python-dateutil to move from /usr/lib to /usr/local/lib, which breaks the pre-installed version of awscli.

Install synapseclient and its dependencies into /usr/lib, and install python-wheel from a system package instead of pypi. Also list all installed python packages for debugging.
