### PR TITLE
[IT-3697] Make sure the correct base image is used

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -22,6 +22,7 @@
         - "ecs-init"
         - "aws-cfn-bootstrap"
         - "chkconfig"
+        - "amazon-ssm-agent"
 
     - name: Install python packages
       ansible.builtin.pip:
@@ -44,13 +45,14 @@
         name: docker
         state: started
 
-    - name: Add the ec2-user to the docker group
+    - name: Add users to the docker group
       ansible.builtin.user:
         name: "{{ item }}"
         groups: docker
         append: yes
       with_items:
         - ec2-user
+        - ssm-user
 
     - name: Make docker auto start
       ansible.builtin.service:

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -19,10 +19,8 @@
         - "git"
         - "python3-pip"
         - "python3-wheel"
-        - "ecs-init"
         - "aws-cfn-bootstrap"
         - "chkconfig"
-        - "amazon-ssm-agent"
 
     - name: Install python packages
       ansible.builtin.pip:

--- a/src/template.json
+++ b/src/template.json
@@ -26,7 +26,7 @@
       "source_ami_filter": {
         "filters": {
           "architecture": "x86_64",
-          "name": "*al2023-ami-*",
+          "name": "al2023-ami-2023*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },


### PR DESCRIPTION
Use the standard base image, not the minimal image or one tuned for specific hardware. Also give `ssm-user` access to run docker.