### PR TITLE
Update precommit and fix linter errors

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,10 +3,9 @@ exclude_paths:
   - .github
   - .pre-commit-config.yaml
 parseable: true
+quiet: true
 skip_list:
-  - "301"
-  - "305"
-  - "306"
+  - "no-changed-when"
   - "name[play]"
   - "name[casing]"
   - "fqcn[action]"

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,11 +1,15 @@
 exclude_paths:
-  - .
   - temp
+  - .github
+  - .pre-commit-config.yaml
 parseable: true
-quiet: true
 skip_list:
-  - 301
-  - 305
-  - 306
+  - "301"
+  - "305"
+  - "306"
+  - "name[play]"
+  - "name[casing]"
+  - "fqcn[action]"
+  - "fqcn[action-core]"
 use_default_rules: true
 verbosity: 1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
       - uses: pre-commit/action@v3.0.0
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
+ci:
+    skip: [ansible-lint]
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.6.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
@@ -9,7 +12,8 @@ repos:
     -   id: pretty-format-json
         args: [--autofix]
 -   repo: https://github.com/ansible/ansible-lint
-    rev: v4.2.0
+    rev: v24.9.2
     hooks:
     -   id: ansible-lint
-        files: packer/.*\.(yaml|yml)$
+        additional_dependencies:
+          - ansible

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -2,12 +2,12 @@
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-basics.html
 
 - hosts: all
-  become: yes
+  become: true
   tasks:
     - name: Upgrade all packages
-      yum:
+      ansible.builtin.yum:
         name: "*"
-        state: latest
+        state: package-latest
         update_cache: true
 
     - name: Install system packages
@@ -46,7 +46,7 @@
     - name: Make docker auto start
       ansible.builtin.service:
         name: "{{ item }}"
-        enabled: yes
+        enabled: true
       with_items:
         - docker
 
@@ -66,7 +66,7 @@
       ansible.builtin.user:
         name: "{{ item }}"
         groups: docker
-        append: yes
+        append: true
       with_items:
         - ec2-user
         - ssm-user


### PR DESCRIPTION
* update pre-commit linters
* Fix or ignore new linter errors
* playbook contains "community.general.sudoers" which requires
   installing `additional_dependencies`.  That however does not
   work with pre-commit SAS service therefore we have to disable
   that linter in the SAS service and run it with github actions.
